### PR TITLE
WIP: Implement crypto API hostcalls

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -6,4 +6,4 @@
 	url = https://github.com/WebAssembly/wasm-c-api
 [submodule "crates/wasi-common/WASI"]
 	path = crates/wasi-common/wig/WASI
-	url = https://github.com/WebAssembly/WASI
+	url = https://github.com/ueno/WASI.git

--- a/crates/test-programs/wasi-tests/Cargo.lock
+++ b/crates/test-programs/wasi-tests/Cargo.lock
@@ -13,7 +13,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 [[package]]
 name = "wasi"
 version = "0.9.0+wasi-snapshot-preview1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
+source = "git+https://github.com/ueno/rust-wasi.git?rev=de47c94ec208bb584cbeea12916f1df7cf025759#de47c94ec208bb584cbeea12916f1df7cf025759"
 
 [[package]]
 name = "wasi-tests"
@@ -21,10 +21,10 @@ version = "0.9.0"
 dependencies = [
  "libc 0.2.66 (registry+https://github.com/rust-lang/crates.io-index)",
  "more-asserts 0.2.1 (registry+https://github.com/rust-lang/crates.io-index)",
- "wasi 0.9.0+wasi-snapshot-preview1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "wasi 0.9.0+wasi-snapshot-preview1 (git+https://github.com/ueno/rust-wasi.git?rev=de47c94ec208bb584cbeea12916f1df7cf025759)",
 ]
 
 [metadata]
 "checksum libc 0.2.66 (registry+https://github.com/rust-lang/crates.io-index)" = "d515b1f41455adea1313a4a2ac8a8a477634fbae63cc6100e3aebb207ce61558"
 "checksum more-asserts 0.2.1 (registry+https://github.com/rust-lang/crates.io-index)" = "0debeb9fcf88823ea64d64e4a815ab1643f33127d995978e099942ce38f25238"
-"checksum wasi 0.9.0+wasi-snapshot-preview1 (registry+https://github.com/rust-lang/crates.io-index)" = "cccddf32554fecc6acb585f82a32a72e28b48f8c4c1883ddfeeeaa96f7d8e519"
+"checksum wasi 0.9.0+wasi-snapshot-preview1 (git+https://github.com/ueno/rust-wasi.git?rev=de47c94ec208bb584cbeea12916f1df7cf025759)" = "<none>"

--- a/crates/test-programs/wasi-tests/Cargo.toml
+++ b/crates/test-programs/wasi-tests/Cargo.toml
@@ -8,7 +8,7 @@ publish = false
 
 [dependencies]
 libc = "0.2.65"
-wasi = "0.9.0"
+wasi = { git = "https://github.com/ueno/rust-wasi.git", rev = "21c1785ff1c0b99b789fa7fdf93c8f5984d10102" }
 more-asserts = "0.2.1"
 
 # This crate is built with the wasm32-wasi target, so it's separate

--- a/crates/wasi-common/Cargo.toml
+++ b/crates/wasi-common/Cargo.toml
@@ -21,6 +21,8 @@ filetime = "0.2.7"
 lazy_static = "1.4.0"
 num = { version = "0.2.0", default-features = false }
 wig = { path = "wig", version = "0.9.2" }
+openssl-sys = "0.9"
+openssl = "0.10"
 
 [target.'cfg(unix)'.dependencies]
 yanix = { path = "yanix", version = "0.9.0" }

--- a/crates/wasi-common/src/cipherentry.rs
+++ b/crates/wasi-common/src/cipherentry.rs
@@ -1,0 +1,37 @@
+use openssl::symm::Cipher;
+use crate::wasi32;
+
+#[allow(dead_code)]
+pub struct CipherSpec {
+    pub(crate) key_size: u32,
+    pub(crate) block_size: u32,
+    pub(crate) nonce_size: u32,
+    pub(crate) tag_size: u32,
+}
+
+pub(crate) struct CipherEntry {
+    pub(crate) cipher: Cipher,
+    pub(crate) key_ptr: wasi32::uintptr_t,
+    pub(crate) key_len: wasi32::size_t,
+    pub(crate) spec: &'static CipherSpec,
+}
+
+impl CipherEntry {
+    pub(crate) fn new(cipher: Cipher,
+                      key_ptr: wasi32::uintptr_t,
+                      key_len: wasi32::size_t,
+                      spec: &'static CipherSpec) -> Self {
+        Self {
+            cipher,
+            key_ptr,
+            key_len,
+            spec,
+        }
+    }
+}
+
+impl std::fmt::Debug for CipherEntry {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(f, "CipherEntry")
+    }
+}

--- a/crates/wasi-common/src/hostcalls_impl/crypto.rs
+++ b/crates/wasi-common/src/hostcalls_impl/crypto.rs
@@ -1,0 +1,258 @@
+#![allow(non_camel_case_types)]
+use crate::ctx::WasiCtx;
+use crate::cipherentry::{CipherEntry, CipherSpec};
+use crate::memory::*;
+use crate::{wasi, wasi32, Error, Result};
+use log::trace;
+use std::str;
+use openssl::symm::{Cipher, Mode, Crypter};
+
+struct CipherImpl {
+    name: &'static str,
+    constructor: fn() -> Cipher,
+    spec: CipherSpec,
+}
+
+const IMPLEMENTED_CIPHERS: &'static [&'static CipherImpl] = &[
+    &CipherImpl {
+        name: "A128GCM",
+        constructor: Cipher::aes_128_gcm,
+        spec: CipherSpec {
+            key_size: 16,
+            block_size: 16,
+            nonce_size: 12,
+            tag_size: 16,
+        }
+    },
+];
+
+pub(crate) fn crypto_aead_open(
+    wasi_ctx: &mut WasiCtx,
+    memory: &mut [u8],
+    algorithm_ptr: wasi32::uintptr_t,
+    algorithm_len: wasi32::size_t,
+    key_ptr: wasi32::uintptr_t,
+    key_len: wasi32::size_t,
+    opened_aead_ptr: wasi32::uintptr_t, // *mut wasi::__wasi_aead_t
+) -> Result<()> {
+    trace!(
+        "crypto_aead_open(algorithm_ptr={:#x?}, algorithm_len={:?})",
+        algorithm_ptr,
+        algorithm_len,
+    );
+
+    let algorithm = dec_slice_of_u8(memory, algorithm_ptr, algorithm_len)
+        .and_then(|s| str::from_utf8(s).map_err(|_| Error::EILSEQ))?;
+
+    let cipher_impl = IMPLEMENTED_CIPHERS
+        .iter().find(|x| x.name == algorithm).ok_or(Error::ENOTSUP)?;
+
+    if key_len != cipher_impl.spec.key_size {
+        return Err(Error::EINVAL);
+    }
+
+    let cipher = (cipher_impl.constructor)();
+    let ce = CipherEntry::new(cipher, key_ptr, key_len, &cipher_impl.spec);
+    let guest_cipher = wasi_ctx.insert_cipher_entry(ce)?;
+    enc_aead_byref(memory, opened_aead_ptr, guest_cipher)
+}
+
+pub(crate) fn crypto_aead_encrypt(
+    wasi_ctx: &WasiCtx,
+    memory: &mut [u8],
+    aead: wasi::__wasi_aead_t,
+    nonce_ptr: wasi32::uintptr_t,
+    nonce_len: wasi32::size_t,
+    auth_ptr: wasi32::uintptr_t,
+    auth_len: wasi32::size_t,
+    data_ptr: wasi32::uintptr_t,
+    data_len: wasi32::size_t,
+    tag_ptr: wasi32::uintptr_t,
+    tag_len: wasi32::size_t,
+) -> Result<()> {
+    trace!(
+        "crypto_aead_encrypt(aead={:?})",
+        aead,
+    );
+
+    let ce = wasi_ctx.get_cipher_entry(aead)?;
+    let key = dec_slice_of_u8(memory, ce.key_ptr, ce.key_len)?;
+    let nonce = dec_slice_of_u8(memory, nonce_ptr, nonce_len)?;
+    let mut encrypter = Crypter::new(
+        ce.cipher,
+        Mode::Encrypt,
+        key,
+        Some(nonce)).map_err(|_| Error::EINVAL)?;
+
+    let auth = dec_slice_of_u8(memory, auth_ptr, auth_len)?;
+    encrypter.aad_update(auth).map_err(|_| Error::EINVAL)?;
+
+    let data_iovs = dec_iovec_slice(memory, data_ptr, data_len)?;
+    let mut block = vec![0; ce.spec.block_size as usize];
+
+    for iov in data_iovs {
+        let data = unsafe {
+            std::slice::from_raw_parts_mut(
+                iov.buf as *mut u8,
+                iov.buf_len)
+        };
+        for chunk in data.chunks_mut(ce.spec.block_size as usize) {
+            encrypter.update(&chunk, &mut block).map_err(|_| Error::EINVAL)?;
+            let len = chunk.len();
+            chunk[..].copy_from_slice(&block[..len]);
+        }
+    }
+    encrypter.finalize(&mut block).map_err(|_| Error::EINVAL)?;
+
+    let mut tag_buf = vec![0; tag_len as usize];
+    encrypter.get_tag(&mut tag_buf).map_err(|_| Error::EINVAL)?;
+
+    enc_slice_of_u8(memory, &tag_buf, tag_ptr)
+}
+
+pub(crate) fn crypto_aead_decrypt(
+    wasi_ctx: &WasiCtx,
+    memory: &mut [u8],
+    aead: wasi::__wasi_aead_t,
+    nonce_ptr: wasi32::uintptr_t,
+    nonce_len: wasi32::size_t,
+    auth_ptr: wasi32::uintptr_t,
+    auth_len: wasi32::size_t,
+    data_ptr: wasi32::uintptr_t,
+    data_len: wasi32::size_t,
+    tag_ptr: wasi32::uintptr_t,
+    tag_len: wasi32::size_t,
+) -> Result<()> {
+    trace!(
+        "crypto_aead_decrypt(aead={:?})",
+        aead,
+    );
+
+    let ce = wasi_ctx.get_cipher_entry(aead)?;
+    let key = dec_slice_of_u8(memory, ce.key_ptr, ce.key_len)?;
+    let nonce = dec_slice_of_u8(memory, nonce_ptr, nonce_len)?;
+    let mut decrypter = Crypter::new(
+        ce.cipher,
+        Mode::Decrypt,
+        key,
+        Some(nonce)).map_err(|_| Error::EINVAL)?;
+
+    let auth = dec_slice_of_u8(memory, auth_ptr, auth_len)?;
+    decrypter.aad_update(auth).map_err(|_| Error::EINVAL)?;
+
+    let tag = dec_slice_of_u8(memory, tag_ptr, tag_len)?;
+    decrypter.set_tag(&tag).map_err(|_| Error::EINVAL)?;
+
+    let data_iovs = dec_iovec_slice(memory, data_ptr, data_len)?;
+    let mut block = vec![0; ce.spec.block_size as usize];
+
+    for iov in data_iovs {
+        let data = unsafe {
+            std::slice::from_raw_parts_mut(
+                iov.buf as *mut u8,
+                iov.buf_len)
+        };
+        for chunk in data.chunks_mut(ce.spec.block_size as usize) {
+            decrypter.update(&chunk, &mut block).map_err(|_| Error::EINVAL)?;
+            let len = chunk.len();
+            chunk[..].copy_from_slice(&block[..len]);
+        }
+    }
+    decrypter.finalize(&mut block).map_err(|_| Error::EINVAL)?;
+
+    Ok(())
+}
+
+pub(crate) fn crypto_aead_close(
+    wasi_ctx: &mut WasiCtx,
+    _memory: &mut [u8],
+    aead: wasi::__wasi_aead_t) -> Result<()> {
+    trace!(
+        "crypto_aead_close(cipher={:?})",
+        aead,
+    );
+
+    wasi_ctx.remove_cipher_entry(aead)?;
+    Ok(())
+}
+
+pub(crate) fn crypto_mac_open(
+    wasi_ctx: &mut WasiCtx,
+    memory: &mut [u8],
+    algorithm_ptr: wasi32::uintptr_t,
+    algorithm_len: wasi32::size_t,
+    key_ptr: wasi32::uintptr_t,
+    key_len: wasi32::size_t,
+    opened_mac_ptr: wasi32::uintptr_t, // *mut wasi::__wasi_mac_t
+) -> Result<()> {
+    trace!(
+        "crypto_mac_open(algorithm_ptr={:#x?}, algorithm_len={:?})",
+        algorithm_ptr,
+        algorithm_len,
+    );
+
+    Err(Error::ENOSYS)
+}
+
+pub(crate) fn crypto_mac_update(
+    wasi_ctx: &WasiCtx,
+    memory: &mut [u8],
+    mac: wasi::__wasi_mac_t,
+    data_ptr: wasi32::uintptr_t,
+    data_len: wasi32::size_t
+) -> Result<()> {
+    trace!(
+        "crypto_mac_update(mac={:?})",
+        mac,
+    );
+
+    Err(Error::ENOSYS)
+}
+
+pub(crate) fn crypto_mac_digest(
+    wasi_ctx: &WasiCtx,
+    memory: &mut [u8],
+    mac: wasi::__wasi_mac_t,
+    digest_ptr: wasi32::uintptr_t,
+    digest_len: wasi32::size_t
+) -> Result<()> {
+    trace!(
+        "crypto_mac_digest(mac={:?})",
+        mac,
+    );
+
+    Err(Error::ENOSYS)
+}
+
+pub(crate) fn crypto_mac_close(
+    wasi_ctx: &mut WasiCtx,
+    memory: &mut [u8],
+    mac: wasi::__wasi_mac_t
+) -> Result<()> {
+    trace!(
+        "crypto_mac_close(mac={:?})",
+        mac,
+    );
+
+    Err(Error::ENOSYS)
+}
+
+pub(crate) fn crypto_hkdf(
+    wasi_ctx: &WasiCtx,
+    memory: &mut [u8],
+    algorithm_ptr: wasi32::uintptr_t,
+    algorithm_len: wasi32::size_t,
+    op: wasi::__wasi_hkdf_operation_t,
+    input_ptr: wasi32::uintptr_t,
+    input_len: wasi32::size_t,
+    output_ptr: wasi32::uintptr_t,
+    output_len: wasi32::size_t,
+) -> Result<()> {
+    trace!(
+        "crypto_hkdf(algorithm_ptr={:#x?}, algorithm_len={:?})",
+        algorithm_ptr,
+        algorithm_len,
+    );
+
+    Err(Error::ENOSYS)
+}

--- a/crates/wasi-common/src/hostcalls_impl/mod.rs
+++ b/crates/wasi-common/src/hostcalls_impl/mod.rs
@@ -2,8 +2,10 @@ mod fs;
 mod fs_helpers;
 mod misc;
 mod sock;
+mod crypto;
 
 pub(crate) use self::fs::*;
 pub(crate) use self::fs_helpers::PathGet;
 pub(crate) use self::misc::*;
 pub(crate) use self::sock::*;
+pub(crate) use self::crypto::*;

--- a/crates/wasi-common/src/lib.rs
+++ b/crates/wasi-common/src/lib.rs
@@ -24,6 +24,7 @@
 mod ctx;
 mod error;
 mod fdentry;
+mod cipherentry;
 pub mod fs;
 mod helpers;
 mod host;

--- a/crates/wasi-common/src/memory.rs
+++ b/crates/wasi-common/src/memory.rs
@@ -244,6 +244,7 @@ dec_enc_scalar!(__wasi_fdflags_t, dec_fdflags_byref, enc_fdflags_byref);
 dec_enc_scalar!(__wasi_device_t, dev_device_byref, enc_device_byref);
 dec_enc_scalar!(__wasi_inode_t, dev_inode_byref, enc_inode_byref);
 dec_enc_scalar!(__wasi_linkcount_t, dev_linkcount_byref, enc_linkcount_byref);
+dec_enc_scalar!(__wasi_aead_t, dec_aead_byref, enc_aead_byref);
 
 pub(crate) fn dec_filestat_byref(
     memory: &mut [u8],


### PR DESCRIPTION
This adds a host implementation of enarx/WASI#1 to wasmtime. To test it, do:
```sh
$ cargo build
$ cargo test --features test_programs
```
The previous step compiles a test program `crates/test-programs/wasi-tests/src/bin/crypto_aead.rs` to WASM. Then you can run it with:
```sh
$ RUST_LOG=wasi_common=trace  ./target/debug/wasmtime run --debug ./target/debug/build/test-programs-c53f0cfcd7e0be3d/out/wasm32-wasi/release/deps/crypto_aead.wasm 0
```